### PR TITLE
api: sync counters

### DIFF
--- a/api/synccounters/atomiclist.go
+++ b/api/synccounters/atomiclist.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 Wireleap
+
+package synccounters
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type atomicList struct {
+	atomic.Value
+	sync.Mutex
+}
+
+func NewList() Map {
+	r := &atomicList{}
+	r.Value.Store([]Tuple{})
+	return r
+}
+
+func (m *atomicList) load(key string) (value *uint64, ok bool) {
+	for _, t := range m.Value.Load().([]Tuple) {
+		if t.Key == key {
+			value, ok = t.Val, true
+			break
+		}
+	}
+	return
+}
+
+func (m *atomicList) append(key string, value *uint64) {
+	m.Lock()
+	l := m.Value.Load().([]Tuple)
+	m.Value.Store(append(l, Tuple{Key: key, Val: value}))
+	m.Unlock()
+}
+
+func (m *atomicList) GetOrInit(key string) *uint64 {
+	v, ok := m.load(key)
+	if ok {
+		return v
+	}
+	var zero uint64 = 0
+	m.append(key, &zero)
+	return &zero
+}
+
+func (m *atomicList) Range(f func(key string, value *uint64) bool) bool {
+	for _, t := range m.Value.Load().([]Tuple) {
+		if !f(t.Key, t.Val) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *atomicList) Reset() (map[string]uint64, bool) {
+	return resetMap(m)
+}

--- a/api/synccounters/concurrent-map.go
+++ b/api/synccounters/concurrent-map.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 Wireleap
+
+package synccounters
+
+import (
+	"sync"
+)
+
+var SHARD_COUNT = 32
+
+// A "thread" safe map of type string:Anything.
+// To avoid lock bottlenecks this map is dived to several (SHARD_COUNT) map shards.
+type concurrentMap []*ConcurrentMapShared
+
+// A "thread" safe string to anything map.
+type ConcurrentMapShared struct {
+	items        map[string]*uint64
+	sync.RWMutex // Read Write mutex, guards access to internal map.
+}
+
+// Creates a new concurrent map.
+func New() concurrentMap {
+	m := make(concurrentMap, SHARD_COUNT)
+	for i := 0; i < SHARD_COUNT; i++ {
+		m[i] = &ConcurrentMapShared{items: make(map[string]*uint64)}
+	}
+	return m
+}
+
+// GetShard returns shard under given key
+func (m concurrentMap) GetShard(key string) *ConcurrentMapShared {
+	return m[uint(fnv32(key))%uint(SHARD_COUNT)]
+}
+
+// Callback to return new element to be inserted into the map
+// It is called while lock is held, therefore it MUST NOT
+// try to access other keys in same map, as it can lead to deadlock since
+// Go sync.RWLock is not reentrant
+type UpsertCb func(exist bool, valueInMap *uint64, newValue *uint64) *uint64
+
+// Sets the given value under the specified key if no value was associated with it.
+func (m concurrentMap) SetIfAbsent(key string, value *uint64) bool {
+	// Get map shard.
+	shard := m.GetShard(key)
+	shard.Lock()
+	_, ok := shard.items[key]
+	if !ok {
+		shard.items[key] = value
+	}
+	shard.Unlock()
+	return !ok
+}
+
+// Get retrieves an element from map under given key.
+func (m concurrentMap) Get(key string) (*uint64, bool) {
+	// Get shard
+	shard := m.GetShard(key)
+	shard.RLock()
+	// Get item from shard.
+	val, ok := shard.items[key]
+	shard.RUnlock()
+	return val, ok
+}
+
+// Used by the Iter & IterBuffered functions to wrap two variables together over a channel,
+type Tuple struct {
+	Key string
+	Val *uint64
+}
+
+// Iterator callback,called for every key,value found in
+// maps. RLock is held for all calls for a given shard
+// therefore callback sess consistent view of a shard,
+// but not across the shards
+type IterCb func(key string, v *uint64) bool
+
+// Callback based iterator, cheapest way to read
+// all elements in a map.
+func (m concurrentMap) IterCb(fn IterCb) bool {
+	for idx := range m {
+		shard := (m)[idx]
+		shard.RLock()
+		bk := false
+		for key, value := range shard.items {
+			if bk = !fn(key, value); bk {
+				shard.RUnlock()
+				return false
+			}
+		}
+		shard.RUnlock()
+	}
+	return true
+}
+
+func fnv32(key string) uint32 {
+	hash := uint32(2166136261)
+	const prime32 = uint32(16777619)
+	for i := 0; i < len(key); i++ {
+		hash *= prime32
+		hash ^= uint32(key[i])
+	}
+	return hash
+}
+
+// Custom Mini API
+type CMap struct{ m concurrentMap }
+
+func NewCMap() Map {
+	c := new(CMap)
+	c.m = New()
+	return c
+}
+
+func (c *CMap) GetOrInit(key string) (value *uint64) {
+	var zero uint64 = 0
+	for { // This loop is due to quantum physics
+		if c.m.SetIfAbsent(key, &zero) {
+			return &zero
+		} else if v, ok := c.m.Get(key); ok {
+			return v
+		}
+	}
+}
+
+func (c *CMap) Range(f func(key string, value *uint64) bool) bool {
+	return c.m.IterCb(f)
+}
+
+func (c *CMap) Reset() (map[string]uint64, bool) {
+	return resetMap(c)
+}

--- a/api/synccounters/map.go
+++ b/api/synccounters/map.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Wireleap
+
+package synccounters
+
+type Map interface {
+	// Returns exisiting counter or initialises a new one
+	GetOrInit(key string) (value *uint64)
+	// Iterate over the entire itemlist
+	// f should return false to abort iteration
+	// Range(f) returns if iteration was completed
+	Range(f func(key string, value *uint64) bool) bool
+	// Reset values to 0
+	// Returns a map[string]uint64 with the previous values, and a completion flag
+	Reset() (map[string]uint64, bool)
+}

--- a/api/synccounters/map_test.go
+++ b/api/synccounters/map_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2021 Wireleap
+
+package synccounters
+
+import (
+	"testing"
+)
+
+func testMap(t *testing.T, newMap func() Map) {
+	m := newMap()
+	x := m.GetOrInit("key1")
+	x_ := m.GetOrInit("key1")
+
+	if x != x_ {
+		t.Error("Incorrect address")
+	}
+
+	m.GetOrInit("key2")
+
+	var counter int
+
+	f := func(key string, value *uint64) bool {
+		counter += 1
+		if counter == 2 {
+			return false
+		}
+		return true
+	}
+
+	if m.Range(f) {
+		t.Error("Iteration should have been aborted")
+	}
+
+	f = func(key string, value *uint64) bool {
+		return true
+	}
+
+	if !m.Range(f) {
+		t.Error("Iteration shouldn't have been aborted")
+	}
+}
+
+func testMapReset(t *testing.T, newMap func() Map) {
+	test_map := map[string]uint64{
+		"key1": uint64(5),
+		"key2": uint64(5),
+	}
+
+	m := newMap()
+
+	// Case1: Initialised synccounters.Map.
+	for k, v := range test_map {
+		x := m.GetOrInit(k)
+		*x = v
+	}
+
+	// Case2: This counter has been pushed in a RWC pipe.
+	x := m.GetOrInit("key1")
+
+	if *x != 5 {
+		t.Error("Item has worng value")
+	}
+
+	ms, ok := m.Reset()
+
+	// Case3: Poped reset result matches original synccounters.Map.
+	if !ok {
+		t.Error("Iteration shouldn't have been aborted")
+	} else if len(ms) != len(test_map) {
+		t.Error("Map length should match")
+	}
+
+	// Case3: Poped reset result matches original synccounters.Map.
+	for k, v := range ms {
+		if test_map[k] != v {
+			t.Error("Values should match")
+		}
+	}
+
+	// Case1: Reset synccounters.Map.
+	m.Range(func(_ string, value *uint64) bool {
+		if *value != 0 {
+			t.Error("Item in map wasn't reset")
+		}
+		return true
+	})
+
+	// Case2: Delegated counter has also been reset.
+	if *x != 0 {
+		t.Error("Item has worng value")
+	}
+}
+
+func TestCMap(t *testing.T) {
+	testMap(t, NewCMap)
+	testMapReset(t, NewCMap)
+}
+
+func TestAtomicList(t *testing.T) {
+	testMap(t, NewList)
+	testMapReset(t, NewCMap)
+}

--- a/api/synccounters/map_utils.go
+++ b/api/synccounters/map_utils.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Wireleap
+
+package synccounters
+
+import (
+	"sync/atomic"
+)
+
+func resetMapFunction() (func(string, *uint64) bool, map[string]uint64) {
+	m := make(map[string]uint64, 0)
+	return func(key string, value *uint64) bool {
+		if _, ok := m[key]; ok {
+			// In theory we're only iterating over each element once
+		} else if value == nil {
+			// Safety check, no address to override ==> ABORT!
+			return false
+		} else {
+			// Save netstat status if not null
+			if old_value := atomic.SwapUint64(value, uint64(0)); old_value != uint64(0) {
+				m[key] = old_value
+			}
+		}
+		return true
+	}, m
+}
+
+func resetMap(m Map) (map[string]uint64, bool) {
+	f, ms := resetMapFunction()
+	return ms, m.Range(f)
+}


### PR DESCRIPTION
Adds:
- Synchronus map of counters, oriented to centralise the network usage measurement by contract.