### PR TITLE
wlnet: Splice with context

### DIFF
--- a/wlnet/plumbing_test.go
+++ b/wlnet/plumbing_test.go
@@ -3,6 +3,7 @@
 package wlnet
 
 import (
+	"context"
 	"bytes"
 	"net"
 	"testing"
@@ -30,8 +31,9 @@ func TestRetransmit(t *testing.T) {
 
 func TestSplice(t *testing.T) {
 	c1, c2 := net.Pipe()
+	ctx := context.Background()
 
-	go Splice(c1, c2, time.Second*0, bufsize)
+	go Splice(ctx, c1, c2, time.Second*0, bufsize)
 
 	_, err := c1.Write(test)
 


### PR DESCRIPTION
This MR adds a cancelation context for the `wlnet/Splice` function.
The purpose is being capable of interrupting the Go routine handling a circuit.