### PR TITLE
wlnet: relay with context

### DIFF
--- a/wlnet/relay/relay.go
+++ b/wlnet/relay/relay.go
@@ -3,6 +3,7 @@
 package relay
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -98,6 +99,9 @@ func (t *T) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ensure the connection is accepted and fail otherwise
+	ctx := context.Background()
+
 	if t.HandleST != nil {
 		err = t.HandleST(p.Token)
 
@@ -160,7 +164,7 @@ func (t *T) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = wlnet.Splice(c, c2, t.MaxTime, t.BufSize)
+	err = wlnet.Splice(ctx, c, c2, t.MaxTime, t.BufSize)
 
 	if err != nil {
 		// TODO more granular errors


### PR DESCRIPTION
Adds context to `wlnet/relay`.

The code location of the [context generation ](https://github.com/SuperBuker/wireleap-common/commit/c5df36437876aa4d695118bb05a87ed75c9c24a6#diff-2c6084a180dc656f71d47d037b770cc14261b7d940aa55effa5c816de28c734fR103) might seem arbitrary, but it's the perfect location to retrieve an external context, for example from the relay Controller, and fail if it's not found.
This design decision also preserves the code parity with the relay repository.