### PR TITLE
cli/fsdir: disable default indent

### DIFF
--- a/changelogs/0.3.7.md
+++ b/changelogs/0.3.7.md
@@ -1,0 +1,13 @@
+# 0.3.7
+
+- fsdir: add Set without indentation, rename existing Set() to SetIndented()
+
+- Includes interface versions:
+    - `clientcontract` v0.1.0
+    - `clientdir` v0.2.0
+    - `clientrelay` v0.2.0
+    - `contractps` v0.1.0
+    - `psauth` v0.1.0
+    - `relaycontract` v0.1.0
+    - `relaydir` v0.2.0
+    - `relayrelay` v0.2.0

--- a/cli/fsdir/fsdir.go
+++ b/cli/fsdir/fsdir.go
@@ -94,7 +94,7 @@ func (t T) Get(x interface{}, ps ...string) error {
 }
 
 // Set marshals the x value into JSON and writes it to the the path ps.
-func (t T) Set(x interface{}, ps ...string) error {
+func (t T) set(x interface{}, indent bool, ps ...string) error {
 	p := t.Path(ps...)
 	err := mkdir(filepath.Dir(p))
 
@@ -102,7 +102,12 @@ func (t T) Set(x interface{}, ps ...string) error {
 		return err
 	}
 
-	b, err := json.MarshalIndent(x, "", "    ")
+	var b []byte
+	if indent {
+		b, err = json.MarshalIndent(x, "", "    ")
+	} else {
+		b, err = json.Marshal(x)
+	}
 
 	if err != nil {
 		return err
@@ -117,7 +122,7 @@ func (t T) Set(x interface{}, ps ...string) error {
 	return nil
 }
 
-// Set marshals the x value into JSON and writes it to the the path ps.
+// Rename moves file from old to new path.
 func (t T) Rename(oldPS, newPS []string) (err error) {
 	op := t.Path(oldPS...)
 	np := t.Path(newPS...)
@@ -128,6 +133,16 @@ func (t T) Rename(oldPS, newPS []string) (err error) {
 	}
 
 	return
+}
+
+// Set marshals the x value into JSON and writes it to the the path ps.
+func (t T) Set(x interface{}, ps ...string) error {
+	return t.set(x, false, ps...)
+}
+
+// SetIndented marshals the x value into indented JSON and writes it to the the path ps.
+func (t T) SetIndented(x interface{}, ps ...string) error {
+	return t.set(x, true, ps...)
 }
 
 // Del deletes the file or directory under a given path.

--- a/cli/fsdir/fsdir.go
+++ b/cli/fsdir/fsdir.go
@@ -113,13 +113,7 @@ func (t T) set(x interface{}, indent bool, ps ...string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(p, b, 0644)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return ioutil.WriteFile(p, b, 0644)
 }
 
 // Rename moves file from old to new path.

--- a/cli/upgrade/config.go
+++ b/cli/upgrade/config.go
@@ -60,7 +60,7 @@ func (u *Config) SkippedVersion() (v *semver.Version) {
 
 func (u *Config) SkipVersion(v semver.Version) error {
 	log.Printf("Skipping version %s", v)
-	return u.fm.Set(v, SKIP_FILENAME)
+	return u.fm.SetIndented(v, SKIP_FILENAME)
 }
 
 func (u *Config) GetChangelog(ver semver.Version) (_ string, err error) {


### PR DESCRIPTION
Added field to disable indent while marshalling.
Breaks current API, requires minor patching in dependant packages.